### PR TITLE
add margin option and optimize calls a bit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # element-scroll-to
 
-Makes sure an element is fully visible on the browser viewport, 
-by recursively scrolling all elements that might be containing it, 
+Makes sure an element is fully visible on the browser viewport,
+by recursively scrolling all elements that might be containing it,
 along with the browser window.
 
 If scrolling the entirety of the element into the viewport is not
@@ -18,8 +18,12 @@ var scrollTo = require('element-scroll-to');
 
 // ...
 
-scrollTo(element);
+scrollTo(element, options);
 ```
+
+options may include:
+
+- `margin` (default 0): additional gutters around the element
 
 ## License
 

--- a/index.es6
+++ b/index.es6
@@ -1,44 +1,53 @@
-function scrollWrapperElements(element) {
+function scrollWrapperElements(element, options) {
+  let elementRect = element.getBoundingClientRect();
   let wrapper = element.parentNode;
+
   while (wrapper != document.body) {
-    let elementRect = element.getBoundingClientRect();
     let wrapperRect = wrapper.getBoundingClientRect();
+    let margin = options.margin;
     let deltaX = 0, deltaY = 0;
-    if (elementRect.top < wrapperRect.top) {
-      deltaY = elementRect.top - wrapperRect.top;
-    } else if (elementRect.bottom > wrapperRect.bottom) {
-      deltaY = elementRect.bottom - wrapperRect.bottom;
+
+    if (elementRect.top < wrapperRect.top + margin) {
+      deltaY = elementRect.top - wrapperRect.top - margin;
+    } else if (elementRect.bottom > wrapperRect.bottom - margin) {
+      deltaY = elementRect.bottom - wrapperRect.bottom + margin;
     }
-    if (elementRect.left < wrapperRect.left) {
-      deltaX = elementRect.left - wrapperRect.left;
-    } else if (elementRect.right > wrapperRect.right) {
-      deltaX = elementRect.right - wrapperRect.right;
+    if (elementRect.left < wrapperRect.left + margin) {
+      deltaX = elementRect.left - wrapperRect.left - margin;
+    } else if (elementRect.right > wrapperRect.right - margin) {
+      deltaX = elementRect.right - wrapperRect.right + margin;
     }
     wrapper.scrollTop += deltaY;
     wrapper.scrollLeft += deltaX;
     wrapper = wrapper.parentNode;
   }
+
+  return elementRect;
 }
 
-function scrollWindow(element) {
-  let elementRect = element.getBoundingClientRect();
+function scrollWindow(element, options, elementRect) {
+  let margin = options.margin;
   let deltaX = 0, deltaY = 0;
-  if (elementRect.top < 0) {
-    deltaY = elementRect.top;
-  } else if (elementRect.bottom > window.innerHeight) {
-    deltaY = elementRect.bottom - window.innerHeight;
+
+  if (elementRect.top < 0 + margin) {
+    deltaY = elementRect.top - margin;
+  } else if (elementRect.bottom > window.innerHeight - margin) {
+    deltaY = elementRect.bottom - window.innerHeight + margin;
   }
-  if (elementRect.left < 0) {
-    deltaX = elementRect.left;
-  } else if (elementRect.right > window.innerWidth) {
-    deltaX = elementRect.right - window.innerWidth;
+  if (elementRect.left < 0 + margin) {
+    deltaX = elementRect.left - margin;
+  } else if (elementRect.right > window.innerWidth - margin) {
+    deltaX = elementRect.right - window.innerWidth + margin;
   }
+
   window.scrollBy(deltaX, deltaY);
 }
 
-function scrollTo(element) {
-  scrollWrapperElements(element);
-  scrollWindow(element); 
+function scrollTo(element, options) {
+  options = options || {}
+  options.margin = options.margin || 0
+  var rect = scrollWrapperElements(element, options);
+  scrollWindow(element, options, rect);
 }
 
 export default scrollTo;


### PR DESCRIPTION
This PR adds a `margin` option so you're not always hugging the container. It also reduces the number of `element.getClientBoundingRect()` calls
