### PR TITLE
remove unused `core-js` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "url": "https://github.com/webmodules/element-scroll-to.git"
   },
   "version": "1.1.0",
-  "dependencies": {
-    "core-js": "0.4.4"
-  },
   "devDependencies": {
     "6to5": "2.12.0",
     "browserify": "8.1.0"


### PR DESCRIPTION
It doesn't look to be used anywhere

cc @coreh @matthewmueller 
